### PR TITLE
 Added fix for 127.0.1.1 address issue on Debian based machines

### DIFF
--- a/src/echoclient.c
+++ b/src/echoclient.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) {
         }
         i = j + 1;
     }
-    assert(rpc_init(0));
+    assert(rpc_init("localhost", 0));
     if ((rpc = rpc_connect(host, port, service, 0)) == NULL) {
         fprintf(stderr, "Failure to connect to %s at %s:%05u\n",
                 service, host, port);

--- a/src/echoserver.c
+++ b/src/echoserver.c
@@ -91,7 +91,7 @@ int main(int argc, char *argv[]) {
         i = j + 1;
     }
 
-    assert(rpc_init(port));
+    assert(rpc_init("localhost", port));
     rps = rpc_offer(service);
     if (rps == NULL) {
         fprintf(stderr, "Failure offering Echo service\n");

--- a/src/srpc.c
+++ b/src/srpc.c
@@ -577,21 +577,30 @@ static int common_init(unsigned short port) {
     return 1;
 }
 
-int rpc_init(unsigned short port) {
+int rpc_init(char *hostname, unsigned short port) {
     char host[128];
     struct hostent *hp;
 
     debugf("rpc_init() entered\n");
     ctable_init();
     stable_init();
-    gethostname(host, 128);
-    hp = gethostbyname(host);
+
+    if (hostname != NULL) {
+        hp = gethostbyname(hostname);
+    } else {
+        gethostname(host, 128);
+        hp = gethostbyname(host);
+    }
+
     if (hp != NULL) {
         struct in_addr tmp;
         memcpy(&tmp, hp->h_addr_list[0], hp->h_length);
         strcpy(my_name, inet_ntoa(tmp));
     } else
         strcpy(my_name, "127.0.0.1");
+
+    debugf("rpc_init() hostname resolution: %s %s\n",
+          (hostname ? hostname : host), my_name);
     return common_init(port);
 }
 

--- a/src/srpc.h
+++ b/src/srpc.h
@@ -58,11 +58,16 @@ struct qdecl {
 #define Q_Arg(QUERY) (&QUERY ## _struct)
 
 /*
- * initialize RPC system - bind to ‘port’ if non-zero
+ * initialize RPC system
+ *
+ * bind to hostname/ip if not NULL
+ * otherwise binds to system hostname
+ *
+ * bind to port if non-zero
  * otherwise port number assigned dynamically
  * returns 1 if successful, 0 if failure
  */
-int rpc_init(unsigned short port);
+ int rpc_init(char *hostname, unsigned short port);
 
 /*
  * the following methods are used by RPC clients
@@ -90,7 +95,7 @@ RpcConnection rpc_connect(char *host, unsigned short port,
 /*
  * make the next RPC call, waiting until response received
  * must be invoked as rpc_call(rpc, Q_Arg(query), qlen, resp, rsize, &rlen)
- * upon successful return, ‘resp’ contains ‘rlen’ bytes of data
+ * upon successful return, ï¿½respï¿½ contains ï¿½rlenï¿½ bytes of data
  * returns 1 if successful, 0 otherwise
  */
 int rpc_call(RpcConnection rpc, const struct qdecl *query, unsigned qlen,
@@ -133,8 +138,8 @@ void rpc_withdraw(RpcService rps);
 unsigned rpc_query(RpcService rps, RpcEndpoint *ep, void *qb, unsigned len);
 
 /*
- * send the next response message to the ‘ep’
- * ‘rb’ contains the response to return to the caller
+ * send the next response message to the ï¿½epï¿½
+ * ï¿½rbï¿½ contains the response to return to the caller
  * returns 1 if successful
  * returns 0 if there is a massive failure in the system
  */

--- a/src/srpc.h
+++ b/src/srpc.h
@@ -63,7 +63,7 @@ struct qdecl {
  * bind to hostname/ip if not NULL
  * otherwise binds to system hostname
  *
- * bind to port if non-zero
+ * bind to `port' if non-zero
  * otherwise port number assigned dynamically
  * returns 1 if successful, 0 if failure
  */
@@ -95,7 +95,7 @@ RpcConnection rpc_connect(char *host, unsigned short port,
 /*
  * make the next RPC call, waiting until response received
  * must be invoked as rpc_call(rpc, Q_Arg(query), qlen, resp, rsize, &rlen)
- * upon successful return, �resp� contains �rlen� bytes of data
+ * upon successful return, `resp' contains `rlen' bytes of data
  * returns 1 if successful, 0 otherwise
  */
 int rpc_call(RpcConnection rpc, const struct qdecl *query, unsigned qlen,
@@ -138,8 +138,8 @@ void rpc_withdraw(RpcService rps);
 unsigned rpc_query(RpcService rps, RpcEndpoint *ep, void *qb, unsigned len);
 
 /*
- * send the next response message to the �ep�
- * �rb� contains the response to return to the caller
+ * send the next response message to the `ep'
+ * `rb' contains the response to return to the caller
  * returns 1 if successful
  * returns 0 if there is a massive failure in the system
  */


### PR DESCRIPTION
- rpc_init() now optionally takes a hostname to resolve, such as
  "localhost", "127.0.0.1", `hostname`.
- This fixes the issue on debian-based machines for which `hostname`
  resolves to "127.0.1.1" and not "127.0.0.1" aka localhost
- If hostname is null rpc_init() will use the system hostname
