### PR TITLE
Fixed compatibility with MACOS, related to #defines

### DIFF
--- a/src/srpc.c
+++ b/src/srpc.c
@@ -33,7 +33,7 @@
  * srpc - a simple UDP-based RPC system
  * originally created to support the Homework event cache
  */
-
+#include "config.h"
 #include "srpc.h"
 #include "srpcdefs.h"
 #include "tslist.h"


### PR DESCRIPTION
 - Configure script defined darwin specific #define in config.h but
   srpc.c did not include it, resulting in issues calculating
   sockaddr_in hashes.
 - Fixed by adding generated config.h to srpc.c's includes